### PR TITLE
Add Oats to Productivity

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -406,7 +406,7 @@ Inspired by the [awesome](https://github.com/sindresorhus/awesome) list.
 
 ### OATS
 
-> Open-source macOS menu bar app for live meeting transcription, speaker labels, and AI summaries, with an offline on-device mode.
+> Open-source local-first macOS meeting-notes app with live meeting transcription, speaker labels, and AI summaries, with an offline on-device mode.
 
 **Cost:** Free
 

--- a/readme.md
+++ b/readme.md
@@ -404,6 +404,16 @@ Inspired by the [awesome](https://github.com/sindresorhus/awesome) list.
 
 [![](images/trello.png)](https://trello.com/)
 
+### OATS
+
+> Open-source macOS menu bar app for live meeting transcription, speaker labels, and AI summaries, with an offline on-device mode.
+
+**Cost:** Free
+
+**Link:** [https://github.com/ariso-ai/oats](https://github.com/ariso-ai/oats)
+
+[![](https://github.com/ariso-ai/oats/raw/main/docs/assets/screenshot-a.png)](https://github.com/ariso-ai/oats)
+
 
 
 ## Text Editing


### PR DESCRIPTION
## Summary

Adds Oats to the Productivity section.

## Fit

Oats is an open-source local-first macOS meeting-notes app for meeting notes, live transcription, speaker labels, and AI summaries. This is not fleet-management tooling, but it fits the list's existing Productivity category for Mac-admin-adjacent day-to-day tools.
